### PR TITLE
Set expiration time for request object

### DIFF
--- a/client.go
+++ b/client.go
@@ -327,6 +327,7 @@ func WithOpenbankingIntentID(intentID string, acr []string) AuthorizeOption {
 		}
 
 		claims := jwt.MapClaims{
+			"exp":   time.Now().Add(time.Minute).Unix(),
 			"nonce": csrf.Nonce,
 			"state": csrf.State,
 			"claims": ClaimRequests{


### PR DESCRIPTION
It's mandatory to send an expiration claim in the request object when a client wants to authorize to openbanking workspace. 
In this PR the expiration claim will be populated automatically when the `WithOpenbankingIntentID` method is used.