### PR TITLE
Append state to the authorize endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -391,6 +391,7 @@ func (c *Client) AuthorizeURL(options ...AuthorizeOption) (authorizeURL string, 
 		"response_type": {"code"},
 		"client_id":     {c.Config.ClientID},
 		"nonce":         {csrf.Nonce},
+		"state":         {csrf.State},
 	}
 
 	if c.Config.RedirectURL != nil {


### PR DESCRIPTION
We have state passing in the signed request object (openbanking scenario).

Now it's also passed in regular authorization calls. Without it, pkce failed with an invalid state error.