### PR TITLE
Client Fixes for Open Banking Brasil

### DIFF
--- a/client.go
+++ b/client.go
@@ -511,13 +511,16 @@ func New(cfg Config) (c Client, err error) {
 		).WithOpenTracing(), nil),
 	}
 
+	openbankingTransport := httptransport.NewWithClient(
+		cfg.IssuerURL.Host,
+		c.apiPathPrefix(cfg.VanityDomainType, "/%s/%s"),
+		[]string{cfg.IssuerURL.Scheme},
+		NewAuthenticator(cc, c.c),
+	)
+	openbankingTransport.Consumers["application/jwt"] = &JWTConsumer{}
+
 	c.Openbanking = &Openbanking{
-		Acp: openbankingClient.New(httptransport.NewWithClient(
-			cfg.IssuerURL.Host,
-			c.apiPathPrefix(cfg.VanityDomainType, "/%s/%s"),
-			[]string{cfg.IssuerURL.Scheme},
-			NewAuthenticator(cc, c.c),
-		).WithOpenTracing(), nil),
+		Acp: openbankingClient.New(openbankingTransport.WithOpenTracing(), nil),
 	}
 
 	apiPrefix := c.apiPathPrefix(cfg.VanityDomainType, "/%s/%s")

--- a/client.go
+++ b/client.go
@@ -538,6 +538,14 @@ func New(cfg Config) (c Client, err error) {
 		).WithOpenTracing(), nil),
 	}
 
+	obbrPaymentsTransport := httptransport.NewWithClient(
+		cfg.IssuerURL.Host,
+		apiPrefix+obbrPayments.DefaultBasePath,
+		[]string{cfg.IssuerURL.Scheme},
+		NewAuthenticator(cc, c.c),
+	)
+	obbrPaymentsTransport.Consumers["application/jwt"] = &JWTConsumer{}
+
 	c.OpenbankingBrasil = &OpenbankingBrasil{
 		Consents: obbrConsents.New(httptransport.NewWithClient(
 			cfg.IssuerURL.Host,
@@ -546,12 +554,7 @@ func New(cfg Config) (c Client, err error) {
 			NewAuthenticator(cc, c.c),
 		).WithOpenTracing(), nil),
 
-		Payments: obbrPayments.New(httptransport.NewWithClient(
-			cfg.IssuerURL.Host,
-			apiPrefix+obbrPayments.DefaultBasePath,
-			[]string{cfg.IssuerURL.Scheme},
-			NewAuthenticator(cc, c.c),
-		).WithOpenTracing(), nil),
+		Payments: obbrPayments.New(obbrPaymentsTransport.WithOpenTracing(), nil),
 	}
 
 	c.Config = cfg

--- a/client.go
+++ b/client.go
@@ -541,14 +541,14 @@ func New(cfg Config) (c Client, err error) {
 	c.OpenbankingBrasil = &OpenbankingBrasil{
 		Consents: obbrConsents.New(httptransport.NewWithClient(
 			cfg.IssuerURL.Host,
-			apiPrefix+obukAccounts.DefaultBasePath,
+			apiPrefix+obbrConsents.DefaultBasePath,
 			[]string{cfg.IssuerURL.Scheme},
 			NewAuthenticator(cc, c.c),
 		).WithOpenTracing(), nil),
 
 		Payments: obbrPayments.New(httptransport.NewWithClient(
 			cfg.IssuerURL.Host,
-			apiPrefix+obukPayments.DefaultBasePath,
+			apiPrefix+obbrPayments.DefaultBasePath,
 			[]string{cfg.IssuerURL.Scheme},
 			NewAuthenticator(cc, c.c),
 		).WithOpenTracing(), nil),

--- a/client.go
+++ b/client.go
@@ -686,14 +686,16 @@ func WithRequestObjectEncryption(key jose.JSONWebKey) AuthorizeOption {
 			err            error
 		)
 
-		encrypter, err = jose.NewEncrypter(jose.A256GCM, jose.Recipient{
+		if encrypter, err = jose.NewEncrypter(jose.A256GCM, jose.Recipient{
 			Algorithm: jose.KeyAlgorithm(key.Algorithm),
 			Key:       key.Key,
 		}, &jose.EncrypterOptions{
 			ExtraHeaders: map[jose.HeaderKey]interface{}{
 				jose.HeaderContentType: "jwt",
 			},
-		})
+		}); err != nil {
+			return errors.Wrapf(err, "failed to create request object encrypter")
+		}
 
 		if jwe, err = encrypter.Encrypt([]byte(token)); err != nil {
 			return errors.Wrapf(err, "failed to encrypt request object")

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.0
 	go.mongodb.org/mongo-driver v1.5.2 // indirect
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8

--- a/go.sum
+++ b/go.sum
@@ -434,8 +434,6 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c h1:pkQiBZBvdos9qq4wBAHqlzuZHEXo07pqV06ef90u1WI=
-golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/jwt_runtime.go
+++ b/jwt_runtime.go
@@ -1,0 +1,41 @@
+package acpclient
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+var parser jwt.Parser
+
+type JWTConsumer struct{}
+
+type JWTClaims map[string]interface{}
+
+func (j *JWTClaims) Valid() error {
+	return nil
+}
+
+func (c *JWTConsumer) Consume(r io.Reader, out interface{}) error {
+	var (
+		claims    JWTClaims
+		body      []byte
+		marshaled []byte
+		err       error
+	)
+
+	if body, err = io.ReadAll(r); err != nil {
+		return err
+	}
+
+	if _, _, err = parser.ParseUnverified(string(body), &claims); err != nil {
+		return err
+	}
+
+	if marshaled, err = json.Marshal(claims); err != nil {
+		return err
+	}
+
+	return json.Unmarshal(marshaled, out)
+}


### PR DESCRIPTION
## Jira task - [5120](https://cloudentity.atlassian.net/browse/AUT-5120)

## Description
This PR fixes two problems that we had with our open banking clients 
1. The base path for the embedded `OpenbankingBrasil` client was fixed. It was using the base path from the obuk package instead of the obbr package
2. A jwt consumer was added to `OpenbankingBrasil` and `Openbanking`, as both of these call some endpoints that return `application/jwt` responses. 

Also, I am not sure how we should handle key retrieval for verifying signed jwts in the jwt consumer, so I have extended it to unpack the response without verification for now.

## Type of changes
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

## Implementation details
