### PR TITLE
AUT-5630 Add xsrf state to otp session to prevent replay attacks

### DIFF
--- a/clients/public/client/transient_otp/get_transient_o_t_p_parameters.go
+++ b/clients/public/client/transient_otp/get_transient_o_t_p_parameters.go
@@ -62,6 +62,9 @@ type GetTransientOTPParams struct {
 	// OtpID.
 	OtpID string
 
+	// State.
+	State *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -126,6 +129,17 @@ func (o *GetTransientOTPParams) SetOtpID(otpID string) {
 	o.OtpID = otpID
 }
 
+// WithState adds the state to the get transient o t p params
+func (o *GetTransientOTPParams) WithState(state *string) *GetTransientOTPParams {
+	o.SetState(state)
+	return o
+}
+
+// SetState adds the state to the get transient o t p params
+func (o *GetTransientOTPParams) SetState(state *string) {
+	o.State = state
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *GetTransientOTPParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -137,6 +151,23 @@ func (o *GetTransientOTPParams) WriteToRequest(r runtime.ClientRequest, reg strf
 	// path param otpID
 	if err := r.SetPathParam("otpID", o.OtpID); err != nil {
 		return err
+	}
+
+	if o.State != nil {
+
+		// query param state
+		var qrState string
+
+		if o.State != nil {
+			qrState = *o.State
+		}
+		qState := qrState
+		if qState != "" {
+
+			if err := r.SetQueryParam("state", qState); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/clients/public/models/transient_o_t_p_request.go
+++ b/clients/public/models/transient_o_t_p_request.go
@@ -34,6 +34,10 @@ type TransientOTPRequest struct {
 	// one-time password
 	// Example: 111111
 	Otp string `json:"otp,omitempty"`
+
+	// Optional XSRF state
+	// Example: c44sqtco4g2legl15m2g
+	State string `json:"state,omitempty"`
 }
 
 // Validate validates this transient o t p request

--- a/spec/public.yaml
+++ b/spec/public.yaml
@@ -707,6 +707,11 @@ definitions:
         format: OTP
         type: string
         x-nullable: false
+      state:
+        description: Optional XSRF state
+        example: c44sqtco4g2legl15m2g
+        type: string
+        x-nullable: false
     required:
     - mechanism
     - address

--- a/spec/public.yaml
+++ b/spec/public.yaml
@@ -803,6 +803,9 @@ paths:
         name: otpID
         required: true
         type: string
+      - in: query
+        name: state
+        type: string
       responses:
         "200":
           $ref: '#/responses/TransientOTPResponse'


### PR DESCRIPTION
## [AUT-5630](https://cloudentity.atlassian.net/browse/AUT-5630)

## Description

Adds an optional state parameter to the transient OTP APIs.
If this parameter is specified when the OTP is sent, then the same value must be specified when OTP  is fetched or verified.
This allows users to mitigate replays and XSRF attacks, by tying the OTP ID to a particular login session, phone number or email address.

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

