### PR TITLE
AUT-6046 Add context parameter to IntrospectToken().

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package acpclient
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
@@ -988,13 +989,14 @@ func (c *Client) Userinfo(token string) (body map[string]interface{}, err error)
 	return body, nil
 }
 
-func (c *Client) IntrospectToken(token string) (*o2models.IntrospectResponse, error) {
+func (c *Client) IntrospectToken(ctx context.Context, token string) (*o2models.IntrospectResponse, error) {
 	var (
 		resp *o2Params.IntrospectOK
 		err  error
 	)
 
 	if resp, err = c.Oauth2.Oauth2.Introspect(o2Params.NewIntrospectParams().
+		WithContext(ctx).
 		WithToken(&token), nil); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## [AUT-6046](https://cloudentity.atlassian.net/browse/AUT-6046)

## BREAKING CHANGE

This pull-request changes the parameters to the IntrospectToken() method.

## Description

The asp-client-go package panics when IntrospectToken is called, because it does not provide a context.
The params.Context value is now required (and therefore the params parameter is no longer optional)
 in `acp-client-go/clients/oauth2/client/oauth2/oauth2_client.go`:
```
 func (a *Client) Introspect(params *IntrospectParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*IntrospectOK, error) {
        // TODO: Validate the params before sending                                                                                                                                                                                                                                                                          
        if params == nil {
                params = NewIntrospectParams()
        }
        op := &runtime.ClientOperation{
                ID:                 "introspect",
                Method:             "POST",
                PathPattern:        "/oauth2/introspect",
                ProducesMediaTypes: []string{"application/json"},
                ConsumesMediaTypes: []string{"application/x-www-form-urlencoded"},
                Schemes:            []string{"https"},
                Params:             params,
                Reader:             &IntrospectReader{formats: a.formats},
                AuthInfo:           authInfo,
                Context:            params.Context,
                Client:             params.HTTPClient,
        }
```
The TODO above should also be addressed, but I assume that would need to happen in the ACP project.
 The params argument, and its fields params.Context and params.HTTPClient, must all be non-nil.

This problem results from the addition of Open-Telemetry support in this commit:
```
1a1f2e24b (Ireneusz Kawalec   2022-03-31 13:55:47 +0200  471)            ).WithOpenTracing(), nil),
```
which causes a panic when `github.com/opentracing/opentracing-go@v1.2.0/gocontext.go` dereferences ctx:
```
 func SpanFromContext(ctx context.Context) Span {
       val := ctx.Value(activeSpanKey)
```

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)


