### PR TITLE
Private Key JWT Support

### DIFF
--- a/client.go
+++ b/client.go
@@ -920,7 +920,7 @@ func (c *Client) Exchange(code string, state string, csrf CSRF) (token Token, er
 		claims := jwt.MapClaims{
 			"iss": c.Config.ClientID,
 			"sub": c.Config.ClientID,
-			"aud": c.Config.TokenURL.String(),
+			"aud": c.Config.GetTokenURL(),
 			"jti": uuid.New().String(),
 			"exp": time.Now().Add(time.Minute * 5).Unix(),
 		}

--- a/client.go
+++ b/client.go
@@ -1032,6 +1032,10 @@ func (c *Client) IntrospectToken(ctx context.Context, token string) (*o2models.I
 	return resp.Payload, nil
 }
 
+func (c *Client) DoRequest(request *http.Request) (*http.Response, error) {
+	return c.c.Do(request)
+}
+
 func randomString(length int) (string, error) {
 	var (
 		data = make([]byte, length)


### PR DESCRIPTION
## Jira task - PUT_JIRA_LINK_HERE

## Description
This PR adds support for `private_key_jwt` client authentication in the `Exchange()` method. 

To enable this, the config `AuthnMethod` must explicitly be set as `PrivateKeyJwtAuthnMethod`. Also, the `ClientAssertionSigningKeyFile` configuration variable must be provided, as this is the private key intended for generating the assertion. 

## Information for QA
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Implementation details

<!--- Describe implementation details if needed -->

## Screenshots (if appropriate):
